### PR TITLE
Updated readme and config options to make initial setup a bit easier

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -12,12 +12,12 @@ This image uses the Home Assistant base image, rather than the native Alpine ima
 
 ## Configuration
 
-Set the database name, username and password  in the yaml editor:
+Set the database name, username and password in the `Configuration` tab of the addon before starting it for the first time:
 
 ```yml
-username: mydbuser
-password: mysecretpassword
-database: mydbname
+username: username
+password: password
+database: databasename
 ```
 
 ## Connecting to the DB

--- a/teslamate/README.md
+++ b/teslamate/README.md
@@ -12,12 +12,12 @@ This addon is part of [my Home Assistant addon repo](https://github.com/matt-FFF
 
 ### DB Connection
 
-If using the Postgres addon from my addon repo, the database host is `29b65938-postgres`. Below is a snippit from the TeslaMate addon configuration, just replace the DB name, username and password and you will be good to go.
+If using the Postgres addon from my addon repo, the database host is `29b65938-postgres`. Below is a snippit from the TeslaMate addon configuration, just replace the DB name, username and password on the `Configuration` tab of the addon before starting it and you will be good to go.
 
 ```yaml
-database_user: mydbuser
-database_pass: mydbpass
-database_name: mydbname
+database_user: username
+database_pass: password
+database_name: databasename
 database_host: 29b65938-postgres
 database_ssl: false
 database_port: 5432

--- a/teslamate/config.json
+++ b/teslamate/config.json
@@ -17,9 +17,9 @@
   "ports": {},
   "ports_description": {},
   "options": {
-    "database_user": "user",
-    "database_pass": "pass",
-    "database_name": "dbname",
+    "database_user": "username",
+    "database_pass": "password",
+    "database_name": "databasename",
     "database_host": "29b65938-postgres",
     "database_ssl": false,
     "database_port": 5432,


### PR DESCRIPTION
With this change, all the documented username/passwords/dbnames are all the same so that if someone didn't figure out where to configure things, they'd still all work.

While we'd certainly not want folks to use defaults, these installs are generally local to their network and simplistic defaults I imagine wouldn't be terrible.